### PR TITLE
`redmineformat` TinyMCE plugin and code syntax highlighting

### DIFF
--- a/app/views/redmine_wysiwyg_editor/_redmine_wysiwyg_editor_partial.html.erb
+++ b/app/views/redmine_wysiwyg_editor/_redmine_wysiwyg_editor_partial.html.erb
@@ -10,6 +10,7 @@ if content_for(:header_tags).present? && content_for(:header_tags).include?('/js
       <%= javascript_include_tag('turndown.js', plugin: 'redmine_wysiwyg_editor') %>
       <%= javascript_include_tag('turndown-plugin-gfm.js', plugin: 'redmine_wysiwyg_editor') %>
     <% end %>
+    <%= javascript_include_tag('RedmineFormatPlugin.js', plugin: 'redmine_wysiwyg_editor') %>
     <%= javascript_include_tag('redmine_wysiwyg_editor.js', plugin: 'redmine_wysiwyg_editor') %>
     <%= stylesheet_link_tag('redmine_wysiwyg_editor.css', plugin: 'redmine_wysiwyg_editor') %>
     <%

--- a/assets/javascripts/RedmineFormatPlugin.js
+++ b/assets/javascripts/RedmineFormatPlugin.js
@@ -1,0 +1,46 @@
+(function() {
+  var CODE_CLASS_PATTERNS = [
+    /^(?:language|code)-(\S+)$/, // CommonMark
+    /^(\S+)\s+syntaxhl$/, // Redmine
+  ];
+
+  tinymce.PluginManager.add('redmineformat', function (editor) {
+    var $ = editor.$;
+
+    function replaceBrWithNl(node) {
+      $(node).find('br').each(function (index, node) {
+        node.parentNode.replaceChild(document.createTextNode('\n'), node);
+      });
+    }
+
+    function codeBlockLanguage(preNode) {
+      var singleChild = preNode.childNodes.length === 1 && preNode.firstChild;
+      var codeNode = singleChild && singleChild.nodeName === 'CODE'
+        && singleChild.className ? singleChild : preNode;
+      if (!codeNode.className) {
+        return null;
+      }
+      return CODE_CLASS_PATTERNS.reduce(function (match, regexp) {
+        return match || (codeNode.className.match(regexp) || [null, null])[1];
+      }, null);
+    }
+
+    editor.on('SetContent', function () {
+      $('pre').filter(function (index, node) {
+        return !!codeBlockLanguage(node);
+      }).each(function (index, node) {
+        var language = codeBlockLanguage(node);
+        replaceBrWithNl(node);
+        node.innerHTML = editor.dom.encode(node.textContent);
+        node.className = "language-" + language;
+      });
+    });
+
+    editor.on('PreProcess', function (e) {
+      $('pre', e.node).each(function (index, node) {
+        replaceBrWithNl(node);
+        node.normalize();
+      });
+    });
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Redmine WYSIWYG Editor plugin",
   "scripts": {
-    "eslint": "eslint assets/javascripts/redmine_wysiwyg_editor.js",
+    "eslint": "eslint assets/javascripts/redmine_wysiwyg_editor.js assets/javascripts/RedmineFormatPlugin.js",
     "test": "mocha test/*.js"
   },
   "author": "Takeshi Nakamura",

--- a/test/hooks/headless.js
+++ b/test/hooks/headless.js
@@ -14,6 +14,8 @@ if (typeof exports === 'object') {
       var tinymce = require('../../assets/javascripts/tinymce/tinymce.min');
       global.tinymce = window.tinymce = tinymce;
       global.RedmineWysiwygEditor = require('../../assets/javascripts/redmine_wysiwyg_editor');
+
+      require('../../assets/javascripts/RedmineFormatPlugin');
     },
     afterAll() {
       delete global.chai;

--- a/test/redmineFormatPlugin.js
+++ b/test/redmineFormatPlugin.js
@@ -1,0 +1,79 @@
+suite('RedmineFormatPlugin', function () {
+  setup(function () {
+    var tempNode = document.createElement('div');
+    tempNode.id = "tempNode";
+    tempNode.style = 'visibility: hidden';
+    document.body.appendChild(tempNode);
+
+    var wysiwygNode = document.createElement('div');
+    wysiwygNode.id = 'wysiwyg';
+    document.getElementById('tempNode').appendChild(wysiwygNode);
+  });
+  teardown(function() {
+    var editor = tinymce.get('wysiwyg');
+    if (editor) {
+      editor.off(null);
+      tinymce.remove('#wysiwyg');
+    }
+    var tempNode = document.getElementById('tempNode');
+    if (tempNode) {
+      tempNode.parentElement.removeChild(tempNode);
+    }
+  });
+
+  /**
+   * Run `testCallback` with RWE TinyMCE editor.
+   *
+   * @param {Array<string>|string} allowedEvents - Events that shouldn't be suppressed.
+   * @param {Function} testCallback - Test function to be run. Initialized TinyMCE
+   *  editor will be provided as function argument and the asynchronous test has to be
+   *  marked with Mocha's `done()`.
+   */
+  function withEditor(allowedEvents, testCallback) {
+    tinymce.init({
+      selector: '#wysiwyg',
+      theme: false,
+      plugins: 'redmineformat',
+      setup: function (editor) {
+        editor.on('init', function(e) {
+          var events = [].concat(allowedEvents).map(function (event) {
+            return event.toLowerCase();
+          });
+          ['SetContent', 'PreProcess'].forEach(function (event) {
+            if (events.indexOf(event.toLowerCase()) < 0) {
+              editor.off(event);
+            }
+          });
+          testCallback(editor);
+        });
+      }
+    });
+  }
+
+  suite('SetContent handler', function () {
+    test('should normalize code block', function (done) {
+      withEditor('SetContent', function (editor) {
+        var c = '<p><pre><code class="java syntaxhl">foo<br>bar</code></pre></p>';
+        editor.setContent(c);
+        assert.equal(editor.getContent(), '<pre class="language-java">foo\nbar</pre>');
+        done();
+      });
+    });
+  });
+
+  suite('PreProcess handler', function () {
+    test('should convert br to nl and normalize text', function (done) {
+      withEditor('PreProcess', function (editor) {
+        var c = '<p><pre>foo<br>bar</pre></p>';
+        editor.on('PreProcess', function (e) {
+          var pre = editor.$('pre', e.node)[0];
+          assert.equal(pre.childNodes.length, 1, 'child node count');
+          assert.equal(pre.firstChild.nodeType, window.Node.TEXT_NODE, 'node type');
+        });
+        editor.setContent(c);
+        assert.equal(editor.getContent(), '<pre>foo\nbar</pre>');
+        done();
+      });
+    });
+  });
+});

--- a/test/test.html
+++ b/test/test.html
@@ -15,6 +15,7 @@
   <script src="../assets/javascripts/turndown.js"></script>
   <script src="../assets/javascripts/turndown-plugin-gfm.js"></script>
   <script src="../assets/javascripts/tinymce/tinymce.min.js"></script>
+  <script src="../assets/javascripts/RedmineFormatPlugin.js"></script>
   <script src="../assets/javascripts/redmine_wysiwyg_editor.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/8.1.3/mocha.min.js"></script>
@@ -22,6 +23,7 @@
   <script src="hooks/globals.js"></script>
 
   <script>mocha.setup('tdd');</script>
+  <script src="redmineFormatPlugin.js"></script>
   <script src="test.js"></script>
   <script>mocha.run();</script>
 </body>


### PR DESCRIPTION
This PR introduces a TinyMCE plugin that allows to separate WYSIWYG concerns from format transformation.

The core idea is to establish a well-defined format for interfacing with the WYSIWYG editor component. Let's call it _visual editor HTML_.
* `redmineformat` plugin inside of TinyMCE is responsible for adapting _visual editor HTML_ to/from WYSIWYG DOM.
* `redmine_wysiwyg_editor` (outside of TinyMCE) is responsible for conversions between markup language (Textile or Markdown with Redmine extensions like macros) and _visual editor HTML_. Most of the operations are indeed delegated to a) libraries like Turndown and b) Redmine itself using AJAX preview call .

`redmineformat` plugin currently addresses code block syntax, which resolves #41. But it also provides a way to resolve other issues like [this fixme](https://github.com/taqueci/redmine_wysiwyg_editor/blob/master/assets/javascripts/redmine_wysiwyg_editor.js#L697).

If the concept is adopted, we'll provide some basic contract documentation for the  _visual editor HTML_ within subsequent PRs (support for macros seems to be the best opportunity :)).

Additional info:
* *Quality assurance*: Added unit tests with headless TinyMCE on top of pure JSDOM.
* Builds on PR #108 