### PR TITLE
Make regex more generic and accept other paths to wiki pages

### DIFF
--- a/assets/javascripts/redmine_wysiwyg_editor.js
+++ b/assets/javascripts/redmine_wysiwyg_editor.js
@@ -929,7 +929,7 @@ RedmineWysiwygEditor.prototype._wikiLinkRule = function() {
       }
 
       var m = href.replace(/\?.+$/, '')
-          .match(/\/projects\/([\w-]+)\/wiki(?:\/([^,./?;:|]+)(#.+)?)?$/);
+          .match(/\/projects\/([\w-]+)\/(?:[\w-]+)(?:\/([^,./?;:|]+)(#.+)?)?$/);
 
       var proj = m[1];
       var page = m[2] ? decodeURIComponent(m[2]) : null;


### PR DESCRIPTION
Hello @taqueci 
I would like to suggest here a change to improve the compatibility with other plugins.

Currently, the plugin has a regex which assumes that all wiki-pages have a URL formatted like this: "projects/name/wiki/"

https://github.com/taqueci/redmine_wysiwyg_editor/blob/8d728c949de1aa409a8833095371399488135448/assets/javascripts/redmine_wysiwyg_editor.js#L931-L932

But I have created another plugin which allows wiki pages to have a different URL, formatted as "projects/name/documentation". (here is this plugin: [Redmine Second Wiki/](https://github.com/nanego/redmine_second_wiki/))
That's why I would like to make the current regex more generic, and accept other kinds of URLs with different paths.

Thank you for considering my request.
