### PR TITLE
Use travis-ci.com instead of travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/taqueci/redmine_wysiwyg_editor.svg?branch=master)](https://travis-ci.org/taqueci/redmine_wysiwyg_editor)
+[![Build Status](https://api.travis-ci.com/taqueci/redmine_wysiwyg_editor.svg?branch=master)](https://app.travis-ci.com/github/taqueci/redmine_wysiwyg_editor)
 
 # Redmine WYSIWYG Editor plugin
 


### PR DESCRIPTION
In README file, when we click on the Travis status button, Travis shows us this message:

`Since June 15th, 2021, the building on [travis-ci.org](http://www.travis-ci.org/) is ceased. Please use [travis-ci.com](http://www.travis-ci.com/) from now on.`

We should allow Travis-ci.com to perform new builds, and update the status badge accordingly.

Thank you!