### PR TITLE
Fix empty text_area on iOS

### DIFF
--- a/assets/javascripts/redmine_wysiwyg_editor.js
+++ b/assets/javascripts/redmine_wysiwyg_editor.js
@@ -817,11 +817,13 @@ RedmineWysiwygEditor.prototype._setTextContent = function() {
 
   var html = self._editor.getContent();
 
-  var text = (self._format === 'textile') ?
-      self._toTextTextile(html) :
-      self._toTextMarkdown(html);
+  if(html) {
+    var text = (self._format === 'textile') ?
+        self._toTextTextile(html) :
+        self._toTextMarkdown(html);
 
-  self._jstEditorTextArea.val(text);
+    self._jstEditorTextArea.val(text);
+  }
 };
 
 var gluableContent = RedmineWysiwygEditor.prototype._gluableContent;


### PR DESCRIPTION
Hi @taqueci.

It seems that in some conditions (when using Textile, 'text' mode, on iOS), the function "setTextContent" clear the value of the textarea. This happens when "editor.getContent" returns no value.

That's why I propose this simple patch to resolve the issue #145.

We should not override the current value when getContent returns an empty string.

Thank you for considering this update.