### PR TITLE
Fix for preview not working with Mentions plugin (#82)

### DIFF
--- a/assets/stylesheets/redmine_wysiwyg_editor.css
+++ b/assets/stylesheets/redmine_wysiwyg_editor.css
@@ -4,6 +4,7 @@
 
 .wysiwyg-editor-preview.wiki-preview {
   background-color: #ffffff;
+  position: relative;
 }
 
 .wysiwyg-editor-preview p {


### PR DESCRIPTION
Adding "position: relative" to .wysiwyg-editor-preview.wiki-preview fixed the problem.
Fixes taqueci/redmine_wysiwyg_editor#82