### PR TITLE
Show different characters depending on the level of indentation

### DIFF
--- a/assets/javascripts/redmine_wysiwyg_editor.js
+++ b/assets/javascripts/redmine_wysiwyg_editor.js
@@ -470,6 +470,7 @@ RedmineWysiwygEditor.prototype._initTinymce = function(setting) {
 
   tinymce.init($.extend({
     // Configurable parameters
+    content_css: "/mpi/plugin_assets/redmine_wysiwyg_editor/stylesheets/wysiwyg_custom.css",
     language: self._language,
     content_style: style,
     height: Math.max(self._jstEditorTextArea.height(), 200),

--- a/assets/stylesheets/wysiwyg_custom.css
+++ b/assets/stylesheets/wysiwyg_custom.css
@@ -1,0 +1,33 @@
+/* plugins/redmine_wysiwyg_editor/assets/stylesheets/wysiwyg_custom.css */
+
+/* Custom Nested List Styling for TinyMCE Editor */
+
+/* Unordered Lists */
+body#tinymce ul {
+list-style-type: disc;
+}
+body#tinymce ul ul {
+list-style-type: circle;
+}
+body#tinymce ul ul ul {
+list-style-type: square;
+}
+body#tinymce ul ul ul ul {
+list-style-type: "- ";
+}
+
+/* Ordered Lists */
+body#tinymce ol {
+list-style-type: decimal;
+}
+body#tinymce ol ol {
+list-style-type: lower-alpha;
+}
+body#tinymce ol ol ol {
+list-style-type: lower-roman;
+}
+body#tinymce ol ol ol ol {
+list-style-type: upper-alpha;
+}
+
+Edit Log time Watch Copy 


### PR DESCRIPTION
This code adds the feature of showing different characters for the first four levels of indent of bullets and numbers inside the wysiwyg editor. Custom css can make the bullets and numbers show up on the page once the editor is closed, but when in edit mode, they will not show without this code.