### PR TITLE
Automatic precompile after initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Project.all.each { |p| p.enable_module!(:visual_editor) }
 ## Installation
 
 1. Clone or copy files into the Redmine plugins directory
-2. Restart Redmine and execute `bundle exec rake assets:precompile`
+2. Restart Redmine 
 3. Enable "Visual editor" in project module settings
 
 ## FAQ / Errors

--- a/init.rb
+++ b/init.rb
@@ -17,3 +17,24 @@ Redmine::Plugin.register :redmine_wysiwyg_editor do
 end
 
 require File.expand_path('lib/redmine_wysiwyg_editor', __dir__)
+
+Rails.application.config.after_initialize do
+  next unless Rails.env.production?
+
+  require 'rake'
+
+  File.open(Rails.root.join('tmp/redmine_wysiwyg_editor_precompile.lock'), 'w') do |file|
+    next unless file.flock(File::LOCK_EX | File::LOCK_NB)
+
+    Rails.logger.info('[redmine_wysiwyg_editor] Running assets:precompile')
+
+    Rails.application.load_tasks
+    Rake::Task['assets:precompile'].reenable
+    Rake::Task['assets:precompile'].invoke
+
+    Rails.logger.info('[redmine_wysiwyg_editor] assets:precompile finished')
+  end
+rescue => e
+  Rails.logger.error("[redmine_wysiwyg_editor] assets:precompile failed: #{e.class}: #{e.message}")
+end
+


### PR DESCRIPTION
Adds an automatic assets:precompile step after Redmine initialization in production, protected by a file lock to avoid concurrent runs. This ensures TinyMCE assets are available after startup without requiring a manual precompile command.